### PR TITLE
[Feat/#48] 축제 상세 조회 api 연동

### DIFF
--- a/src/components/common/AttractionCard.tsx
+++ b/src/components/common/AttractionCard.tsx
@@ -129,7 +129,7 @@ const AttractionCard: React.FC<AttractionCardProps> = ({
             onPress={() =>
               onToggleLike &&
               onToggleLike(
-                isPlace ? placeData.place_id : festivalData.festival_id,
+                isPlace ? placeData.place_id : festivalData.id,
               )
             }>
             <IcHeart

--- a/src/screens/FestivalScreen.tsx
+++ b/src/screens/FestivalScreen.tsx
@@ -174,13 +174,14 @@ const FestivalScreen = () => {
             <AttractionCard
               place={
                 {
-                  place_id: item.data.id,
+                  id: item.data.id,
                   name: item.data.name,
                   is_like: item.data.is_like,
                   address: item.data.address,
                   img: item.data.img,
                   start_date: item.data.start_date,
                   end_date: item.data.end_date,
+                  like_amount: item.data.like_amount,
                 } as any
               }
               cardType={CardType.FESTIVAL}

--- a/src/services/festivalService.ts
+++ b/src/services/festivalService.ts
@@ -10,6 +10,7 @@ import {
   FestivalListParams,
   FestivalSortType,
   FestivalStatusType,
+  FestivalDetailResult,
 } from '../types/festival';
 
 export class FestivalService {
@@ -87,6 +88,78 @@ export class FestivalService {
       return data;
     } catch (error) {
       console.error('=== 지역축제 목록 조회 API 에러 ===');
+      console.error('에러 상세:', error);
+      throw error;
+    }
+  }
+
+  /**
+   * 지역축제 상세 조회
+   */
+  static async getFestivalDetail(
+    festivalId: number,
+  ): Promise<BaseApiResponse<FestivalDetailResult>> {
+    try {
+      const accessToken = await AsyncStorage.getItem('accessToken');
+      console.log('=== FestivalService 상세조회 API 요청 시작 ===');
+      console.log('accessToken:', accessToken);
+      console.log('festivalId:', festivalId);
+
+      const url = `${this.baseUrl}${API_ENDPOINTS.FESTIVALS}/${festivalId}`;
+
+      console.log('=== 지역축제 상세 조회 API 호출 ===');
+      console.log('API URL:', url);
+
+      const controller = new AbortController();
+      const timeoutId = setTimeout(
+        () => controller.abort(),
+        API_CONFIG.TIMEOUT,
+      );
+
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      console.log('=== API 응답 정보 ===');
+      console.log('응답 상태:', response.status);
+      console.log('응답 상태 텍스트:', response.statusText);
+
+      const responseText = await response.text();
+      console.log('응답 데이터:', responseText);
+
+      if (!response.ok) {
+        console.error('=== 지역축제 상세 조회 API 호출 실패 ===');
+        console.error('상태 코드:', response.status);
+        console.error('응답 내용:', responseText);
+
+        throw new Error(
+          `HTTP error! status: ${response.status}, response: ${responseText}`,
+        );
+      }
+
+      const data: BaseApiResponse<FestivalDetailResult> =
+        JSON.parse(responseText);
+
+      console.log('=== 지역축제 상세 조회 API 응답 성공 ===');
+      console.log('응답 데이터:', {
+        isSuccess: data.is_success,
+        code: data.code,
+        message: data.message,
+        festivalId: data.result?.id,
+        festivalName: data.result?.name,
+      });
+
+      return data;
+    } catch (error) {
+      console.error('=== 지역축제 상세 조회 API 에러 ===');
       console.error('에러 상세:', error);
       throw error;
     }

--- a/src/types/festival.ts
+++ b/src/types/festival.ts
@@ -12,16 +12,32 @@ export interface FestivalListItem {
 export interface FestivalDetail {
   id: number;
   name: string;
-  like_count: number;
+  like_amount: number;
   start_date: string;
   end_date: string;
   address: string;
   phone: string;
-  fee: number;
+  fee: string;
   introduce: string;
-  img?: string;
+  img?: [string, string[]];
   is_like: boolean;
   site_url?: string;
+}
+
+export interface FestivalDetailResult {
+  "@class": string;
+  id: number;
+  img: [string, string[]];
+  name: string;
+  like_amount: number;
+  is_like: boolean;
+  start_date: string;
+  end_date: string;
+  address: string;
+  phone: string;
+  fee: string;
+  site_url: string;
+  introduce: string;
 }
 
 export interface FestivalListResult {


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) [Feat/#1] 로그인 페이지 UI 구현 -->

## 작업 내용
<!-- 이번 PR에서 작업한 내용을 설명해주세요 -->
- 축제 상세 조회 api 연동

## 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면 closed #Issue_number를 적어주세요 -->
- closed #48 


## 체크리스트
- [x] 로컬 빌드 확인
- [x] 실행 시 에러 확인


## 스크린샷 (선택)

<img width="270" height="600" alt="Screenshot_1756289175" src="https://github.com/user-attachments/assets/23b148ae-c17b-47f1-abe3-cf63cc74f69a" />

## 기타 사항 (선택)
- festival_id 필드명 id로 통일
- like_count 필드명 like_amount로 변경(실제 응답) 추후 백엔드에서 수정 후 like_count로 통일 예정